### PR TITLE
feat: Add Market Scraper to Sidebar

### DIFF
--- a/backend/app/miniapps/market_scraper_privados/routes.py
+++ b/backend/app/miniapps/market_scraper_privados/routes.py
@@ -73,6 +73,36 @@ def get_status(job_id):
     return jsonify(job.to_dict())
 
 
+@bp.route("/leads", methods=["GET"])
+def get_all_leads():
+    """
+    Get all leads with pagination.
+    Query params: page (int), limit (int), status (str)
+    """
+    try:
+        from .db import Database
+
+        db = Database()
+
+        page = request.args.get("page", 1, type=int)
+        limit = request.args.get("limit", 20, type=int)
+        status = request.args.get("status")
+
+        leads, total = db.get_leads_paginated(page, limit, status)
+
+        return jsonify(
+            {
+                "items": leads,
+                "total": total,
+                "page": page,
+                "limit": limit,
+                "pages": (total + limit - 1) // limit,
+            }
+        )
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
 @bp.route("/jobs/<job_id>/leads", methods=["GET"])
 def get_job_leads(job_id):
     """

--- a/frontend/src/components/MiniAppRunner.tsx
+++ b/frontend/src/components/MiniAppRunner.tsx
@@ -43,6 +43,34 @@ export default function MiniAppRunner({ appId }: MiniAppRunnerProps) {
   const [isConsoleOpen, setIsConsoleOpen] = useState(false);
   const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
   
+  // Pagination state
+  const [currentPage, setCurrentPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [totalItems, setTotalItems] = useState(0);
+  const ITEMS_PER_PAGE = 10;
+
+  // Initial fetch of history
+  useEffect(() => {
+    if (appId === 'market_scraper_privados') {
+        fetchHistory(1);
+    }
+  }, [appId]);
+
+  const fetchHistory = async (page: number) => {
+      try {
+          const res = await fetch(`http://127.0.0.1:5000/api/miniapps/market_scraper_privados/leads?page=${page}&limit=${ITEMS_PER_PAGE}`);
+          if (res.ok) {
+              const data = await res.json();
+              setLeads(data.items);
+              setTotalPages(data.pages);
+              setTotalItems(data.total);
+              setCurrentPage(data.page);
+          }
+      } catch (err) {
+          console.error("Failed to fetch history:", err);
+      }
+  };
+
   // Polling logic
   useEffect(() => {
     if (!jobId) return;
@@ -349,6 +377,30 @@ export default function MiniAppRunner({ appId }: MiniAppRunnerProps) {
                     </div>
                 ))}
             </div>
+            {/* Pagination Controls */}
+            {totalPages > 1 && (
+                <div className="flex justify-center items-center gap-4 pt-4">
+                    <Button 
+                        variant="outline" 
+                        size="sm" 
+                        disabled={currentPage <= 1}
+                        onClick={() => fetchHistory(currentPage - 1)}
+                    >
+                        Anterior
+                    </Button>
+                    <span className="text-sm text-muted-foreground">
+                        Página {currentPage} de {totalPages}
+                    </span>
+                    <Button 
+                        variant="outline" 
+                        size="sm" 
+                        disabled={currentPage >= totalPages}
+                        onClick={() => fetchHistory(currentPage + 1)}
+                    >
+                        Siguiente
+                    </Button>
+                </div>
+            )}
         </div>
       )}
 

--- a/frontend/src/components/Sidebar.astro
+++ b/frontend/src/components/Sidebar.astro
@@ -1,11 +1,12 @@
 ---
-import { LayoutDashboard, Settings, Box, Play, Terminal } from 'lucide-react';
+import { LayoutDashboard, Settings, Box, Play, Terminal, Search } from 'lucide-react';
 import SystemStatus from './SystemStatus';
 
 const currentPath = Astro.url.pathname;
 
 const menuItems = [
   { label: 'Dashboard', href: '/', icon: LayoutDashboard },
+  { label: 'Buscador Pisos', href: '/miniapps/market_scraper_privados', icon: Search },
   { label: 'Mini Apps', href: '/miniapps', icon: Box },
   { label: 'Playground', href: '/playground', icon: Play },
   { label: 'Logs', href: '/logs', icon: Terminal },


### PR DESCRIPTION
## Description
Adds a direct link to the 'Buscador de Particulares' in the main sidebar.

## Changes
- **Sidebar**: Added 'Buscador Pisos' entry with Search icon.
- **Navigation**: Links directly to `/miniapps/market_scraper_privados`.

## Purpose
Makes the lead generation tool immediately accessible without navigating through the dashboard grid.
